### PR TITLE
test workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,17 @@
+name: coverage
+
+on: [pull_request, push]
+jobs:
+  test:
+    name: coverage
+    runs-on: ubuntu-latest
+    container:
+      image: xd009642/tarpaulin:0.22.0
+      options: --security-opt seccomp=unconfined
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Generate code coverage
+        run: |
+          cargo tarpaulin --verbose --workspace --timeout 120 --out xml --avoid-cfg-tarpaulin

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,16 @@
+name: linter
+on: push
+
+# Make sure CI fails on all warnings, including Clippy lints
+env:
+  RUSTFLAGS: "-Dwarnings"
+
+jobs:
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run Clippy
+        run: cargo clippy --all-targets -- -D warnings
+      - name: Format
+        run: cargo fmt --all -- --check --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+output.txt
 */target/
 .vscode/
 */contracts/*/target


### PR DESCRIPTION
tested ctf-01/*

SUMMARY
===
coverage: 95.83% coverage, 46/48 lines covered
linter: error: could not compile `oaksecurity-cosmwasm-ctf-01` due to 3 previous errors
fmt: pass
ai-pr-review: summary and walkthrough generated
ai-audit: ❌ **1 critical**

COVERAGE DETAILS
===
|| Uncovered Lines:
|| src/contract.rs: 45, 93
|| Tested/Total Lines:
|| src/bin/schema.rs: 1/1
|| src/contract.rs: 45/47
|| 
95.83% coverage, 46/48 lines covered

LINTER DETAILS
===
```
error: redundant clone
  --> src/integration_tests.rs:55:19
   |
55 |             sender.clone(),
   |                   ^^^^^^^^ help: remove this
   |
note: this value is dropped without further use
  --> src/integration_tests.rs:55:13
   |
55 |             sender.clone(),
   |             ^^^^^^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone
   = note: `-D clippy::redundant-clone` implied by `-D warnings`

error: redundant clone
  --> src/integration_tests.rs:72:38
   |
72 |                 to_address: recipient.to_owned(),
   |                                      ^^^^^^^^^^^ help: remove this
   |
note: this value is dropped without further use
  --> src/integration_tests.rs:72:29
   |
72 |                 to_address: recipient.to_owned(),
   |                             ^^^^^^^^^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone

error: redundant clone
   --> src/integration_tests.rs:146:69
    |
146 |         let res = app.execute_contract(hacker.clone(), contract_addr.clone(), &msg, &[]);
    |                                                                     ^^^^^^^^ help: remove this
    |
note: this value is dropped without further use
   --> src/integration_tests.rs:146:56
    |
146 |         let res = app.execute_contract(hacker.clone(), contract_addr.clone(), &msg, &[]);
    |                                                        ^^^^^^^^^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone

error: could not compile `oaksecurity-cosmwasm-ctf-01` due to 3 previous errors
```
AI AUDIT DETAILS
===

There is a significant accounting / balance discrepancy vulnerability in the withdrawal function, specifically in the "withdraw" function in the "contract.rs" file. This function does not dedupe lockup ids when withdrawing, leading to a vulnerability of calling multiple duplicate ids to drain the contract balance.

Here is the relevant code:

```rust
pub fn withdraw(deps: DepsMut, env: Env, info: MessageInfo, ids: Vec<u64>,) -> Result<Response, ContractError> {
    // ...
    for lockup in lockups {
        if lockup.owner != info.sender || env.block.time < lockup.release_timestamp {
            return Err(ContractError::Unauthorized { });
        }
        total_amount += lockup.amount;
        LOCKUPS.remove(deps.storage, lockup.id);
    }
    // ...
}
```

The for loop `for lockup in lockups` is intended to iterate different lockup ids. However, it does not dedupe in the case of duplicate lockup ids. So if the same lockup id is passed multiple times, the contract can be drained.

### Recommendation

To fix this issue, you can either only withdraw 1 id per message, or dedupe the ids vec. Here's an example of deduping the ids vec:

```rust
pub fn withdraw(deps: DepsMut, env: Env, info: MessageInfo, ids: Vec<u64>,) -> Result<Response, ContractError> {
    // ...
    let mut ids = ids;
    ids.sort();
    ids.dedup();

    for lockup_id in ids.clone().into_iter() {
    // ...
}
```

With this fix, the contract will only withdraw 1 time per lockup id.